### PR TITLE
Real-time streaming (SSE) for immediately-sourced flags

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -20,9 +20,10 @@ switches, synchronized across application zones, with progressive rollout.
 **Honest current state:** flags are grouped into hierarchical **chambers** that
 inherit from their parents; values can be overridden per **application version
 range** and rolled out to a **deterministic percentage** of subjects; the SDK
-stays current by **polling** (default 15 min). Not yet built: attribute-based
-targeting, real-time streaming ("immediately sourced"), API-key auth, and audit
-logging. See `docs/ARCHITECTURE.md` for the full gap analysis.
+stays current by **polling** (default 15 min) or **real-time streaming**
+(opt-in SSE, "immediately sourced"). Not yet built: attribute-based targeting,
+cross-replica stream fanout, API-key auth, and audit logging. See
+`docs/ARCHITECTURE.md` for the full gap analysis.
 
 ## Domain vocabulary
 
@@ -46,8 +47,12 @@ Read `pkg/rule.go`, `pkg/override.go`, `pkg/rollout.go`, `pkg/chamber.go`,
   `InheritFrom` / `OverwriteFrom`. **ChamberEntry** is the immutable,
   version-bound read view the SDK evaluates against.
 - **Realm** — the SDK client object (`NewRealm(WithHttpClient, WithPath,
-  WithVersion, WithPollingInterval)`; `Start`/`Stop`; `Bool`/`String`/`Float64`/
-  `CustomValue`; `NewContext` / `NewContextWithEvaluation`).
+  WithVersion, WithPollingInterval, WithStreaming)`; `Start`/`Stop`; `Bool`/
+  `String`/`Float64`/`CustomValue`; `NewContext` / `NewContextWithEvaluation`).
+  Refresh is either **polling** (default) or **streaming** (`WithStreaming(true)`
+  → SSE `GET /v1/chambers/<path>?watch=true`, with polling fallback). The server
+  pushes changes via an in-process **broker** (`http/broker.go`, notified after
+  each write). See `docs/ARCHITECTURE.md`.
 
 ## Architecture map
 

--- a/README.md
+++ b/README.md
@@ -127,3 +127,24 @@ unaffected.
 ctx := rlm.NewContextWithEvaluation(r.Context(), realm.EvaluationContext{Key: userID})
 enabled, _ := rlm.Bool(ctx, "new-checkout", false) // true for ~20% of users
 ```
+
+### real-time updates (streaming)
+
+By default the SDK polls (every 15 min). Opt into streaming with
+`WithStreaming(true)` and flag changes are pushed to the client over
+server-sent events within milliseconds, with automatic fallback to polling if
+the server doesn't support it.
+
+```go
+rlm, _ := realm.NewRealm(
+	realm.WithHttpClient(client),
+	realm.WithPath("root"),
+	realm.WithStreaming(true),
+)
+```
+
+You can watch a chamber directly over HTTP too:
+
+```bash
+curl -N 'http://localhost:8080/v1/chambers/root?watch=true'
+```

--- a/client/http.go
+++ b/client/http.go
@@ -28,6 +28,9 @@ type HttpClientConfig struct {
 
 type HttpClient struct {
 	underlying *http.Client
+	// streaming is used for long-lived watch connections and therefore has no
+	// overall client timeout (which would sever the stream).
+	streaming  *http.Client
 	address    *url.URL
 	tracer     trace.Tracer
 	propagator propagation.TextMapPropagator
@@ -49,10 +52,28 @@ func NewHttpClient(c *HttpClientConfig) (*HttpClient, error) {
 
 	return &HttpClient{
 		underlying: &http.Client{Timeout: c.Timeout, Transport: otelhttp.NewTransport(http.DefaultTransport)},
+		streaming:  &http.Client{Transport: otelhttp.NewTransport(http.DefaultTransport)},
 		address:    u,
 		tracer:     tracer,
 		propagator: otel.GetTextMapPropagator(),
 	}, nil
+}
+
+// Watch opens a long-lived server-sent-events stream of the chamber at path.
+// The request is not subject to the client's overall timeout, so the stream can
+// stay open. The caller must close the returned response body.
+func (c *HttpClient) Watch(ctx context.Context, path string) (*http.Response, error) {
+	logger := logging.Ctx(ctx)
+	logger.DebugCtx(ctx).Str("path", path).Msg("opening chamber watch stream")
+
+	target := c.address.Scheme + "://" + c.address.Host + "/v1/chambers/" + strings.TrimPrefix(path, "/") + "?watch=true"
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, target, nil)
+	if err != nil {
+		return nil, err
+	}
+	req.Header.Set("Accept", "text/event-stream")
+	c.propagator.Inject(ctx, propagation.HeaderCarrier(req.Header))
+	return c.streaming.Do(req)
 }
 
 func (c *HttpClient) NewRequest(ctx context.Context, method string, path string, body io.Reader) (*http.Request, error) {

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -81,10 +81,31 @@ Go SDK (Realm)  ┼─► client.HttpClient ─► HTTP /v1/chambers/<path> ─�
   new rule capabilities need **no** handler changes.
 
 The SDK (`pkg/realm.go`) fetches the chamber at its configured path on `Start`
-and then refreshes on a ticker (`DefaultPollingInterval = 15m`), swapping the
-immutable `ChamberEntry` snapshot under a mutex. Reads (`Bool`/`String`/
-`Float64`/`CustomValue`) pull the snapshot (and any `EvaluationContext`) from the
-request context.
+and then keeps it current, swapping the immutable `ChamberEntry` snapshot under a
+mutex. Reads (`Bool`/`String`/`Float64`/`CustomValue`) pull the snapshot (and any
+`EvaluationContext`) from the request context. Two refresh modes:
+
+- **Polling (default)** — refetch on a ticker (`DefaultPollingInterval = 15m`).
+- **Streaming (`WithStreaming(true)`)** — hold an SSE connection open and apply
+  changes as the server pushes them ("immediately sourced"). The SDK reconnects
+  with capped exponential backoff and **falls back to polling** if the server
+  does not return an event stream (detected via `Content-Type`).
+
+### Real-time updates (SSE)
+
+`GET /v1/chambers/<path>?watch=true` returns a `text/event-stream` that emits an
+`event: chamber` with the current chamber immediately, then again on every
+change, plus periodic heartbeat comments. On the server, an in-process **broker**
+(`http/broker.go`) is notified after each write (`Put`/`Patch`/`Delete`) and
+wakes watchers whose path is at or below the changed path (prefix match), so an
+inherited parent change refreshes child watchers. The watch request bypasses the
+per-request timeout; the endpoint reuses the same storage `Get` as a normal read,
+so inheritance and validation are identical.
+
+**Limitation (first cut):** the broker is process-local. With multiple server
+replicas, a write on replica A does not push to watchers connected to replica B;
+those converge on their next reconnect or poll. Cross-replica fanout (a shared
+bus, or each replica watching its storage source) is a follow-up.
 
 ## Storage
 
@@ -126,7 +147,8 @@ Handlers and commands wrap work in `tracer.Start(ctx, "…")`.
 | **Percentage rollout (deterministic bucketing)** | ✅ Done | `pkg/rollout.go` |
 | Hierarchy / inheritance (proto "zones") | ✅ Done | `pkg/storage/inheritable.go` |
 | Attribute/segment targeting (rules on `EvaluationContext.Attributes`) | ⬜ Next | seam exists in `pkg/context.go` |
-| Real-time streaming ("immediately sourced", SSE) instead of polling | ⬜ Next | `pkg/realm.go` polling loop |
+| **Real-time streaming ("immediately sourced", SSE)** | ✅ Done | `http/broker.go`, `streamChamber` in `http/handler.go`, `Realm.stream` in `pkg/realm.go` |
+| Cross-replica stream fanout (multi-instance) | ⬜ Next | broker is process-local today |
 | Environment API-key auth | ⬜ Next | `http/handler.go` middleware |
 | Audit log of flag changes | ⬜ Next | around `http/handler.go` write ops |
 | Multi-language SDKs | ⬜ Next | new clients against `/v1/chambers` |

--- a/http/broker.go
+++ b/http/broker.go
@@ -1,0 +1,83 @@
+package http
+
+import (
+	"strings"
+	"sync"
+
+	"github.com/steviebps/realm/utils"
+)
+
+// broker is an in-process publish/subscribe hub that notifies chamber watchers
+// when a chamber at (or above) their watched path changes.
+//
+// It is deliberately small: subscribers receive a coalesced "you are stale"
+// signal rather than the changed data, so a slow subscriber can never block a
+// writer and at most one pending signal is ever queued per subscriber.
+//
+// The broker is process-local. With multiple server replicas, a write handled
+// by one replica does not notify watchers connected to another; those watchers
+// converge on their next reconnect or poll. Cross-replica fanout is a follow-up
+// (see docs/ARCHITECTURE.md).
+type broker struct {
+	mu   sync.Mutex
+	subs map[int]*subscription
+	next int
+}
+
+type subscription struct {
+	// path is the watched chamber path, normalized with a trailing slash.
+	path string
+	// ch carries change signals. It has a buffer of one and sends are
+	// non-blocking, so it holds at most one pending "stale" signal.
+	ch chan struct{}
+}
+
+func newBroker() *broker {
+	return &broker{subs: make(map[int]*subscription)}
+}
+
+// Subscribe registers a watcher for watchPath and returns a channel that
+// receives a signal whenever a change affects that path, along with a function
+// that unregisters the watcher and closes the channel.
+func (b *broker) Subscribe(watchPath string) (<-chan struct{}, func()) {
+	sub := &subscription{
+		path: utils.EnsureTrailingSlash(watchPath),
+		ch:   make(chan struct{}, 1),
+	}
+
+	b.mu.Lock()
+	id := b.next
+	b.next++
+	b.subs[id] = sub
+	b.mu.Unlock()
+
+	unsubscribe := func() {
+		b.mu.Lock()
+		delete(b.subs, id)
+		b.mu.Unlock()
+	}
+
+	return sub.ch, unsubscribe
+}
+
+// Notify wakes every subscriber whose watched path is at or below changedPath.
+//
+// A watcher on "/a/b/" is affected by a write to "/a/" (its inherited view may
+// change) but not by a write to "/a/b/c/". Matching is therefore a prefix test:
+// the watched path must start with the changed path.
+func (b *broker) Notify(changedPath string) {
+	changed := utils.EnsureTrailingSlash(changedPath)
+
+	b.mu.Lock()
+	defer b.mu.Unlock()
+	for _, sub := range b.subs {
+		if !strings.HasPrefix(sub.path, changed) {
+			continue
+		}
+		// Non-blocking: if a signal is already pending, coalesce into it.
+		select {
+		case sub.ch <- struct{}{}:
+		default:
+		}
+	}
+}

--- a/http/broker_test.go
+++ b/http/broker_test.go
@@ -1,0 +1,103 @@
+package http
+
+import (
+	"testing"
+	"time"
+)
+
+func received(ch <-chan struct{}) bool {
+	select {
+	case <-ch:
+		return true
+	case <-time.After(100 * time.Millisecond):
+		return false
+	}
+}
+
+func TestBrokerNotifyExactPath(t *testing.T) {
+	b := newBroker()
+	ch, unsub := b.Subscribe("root/")
+	defer unsub()
+
+	b.Notify("root/")
+	if !received(ch) {
+		t.Fatal("expected a signal for an exact path match")
+	}
+}
+
+func TestBrokerNotifyParentWakesChild(t *testing.T) {
+	b := newBroker()
+	// A watcher on the child must be notified when the parent changes, because
+	// under inheritable storage the child's merged view changes too.
+	ch, unsub := b.Subscribe("a/b/")
+	defer unsub()
+
+	b.Notify("a/")
+	if !received(ch) {
+		t.Fatal("expected a parent write to wake a child watcher")
+	}
+}
+
+func TestBrokerNotifyChildDoesNotWakeParent(t *testing.T) {
+	b := newBroker()
+	ch, unsub := b.Subscribe("a/")
+	defer unsub()
+
+	b.Notify("a/b/c/")
+	if received(ch) {
+		t.Fatal("a deeper write should not wake an ancestor watcher")
+	}
+}
+
+func TestBrokerNotifyUnrelatedPath(t *testing.T) {
+	b := newBroker()
+	ch, unsub := b.Subscribe("a/b/")
+	defer unsub()
+
+	b.Notify("x/y/")
+	if received(ch) {
+		t.Fatal("an unrelated write should not wake the watcher")
+	}
+}
+
+func TestBrokerUnsubscribeStopsSignals(t *testing.T) {
+	b := newBroker()
+	ch, unsub := b.Subscribe("root/")
+	unsub()
+
+	b.Notify("root/")
+	if received(ch) {
+		t.Fatal("expected no signal after unsubscribe")
+	}
+}
+
+func TestBrokerNotifyIsNonBlockingAndCoalesces(t *testing.T) {
+	b := newBroker()
+	ch, unsub := b.Subscribe("root/")
+	defer unsub()
+
+	// Many notifies with no reader must not block; they coalesce into the
+	// single-slot buffer.
+	for i := 0; i < 100; i++ {
+		b.Notify("root/")
+	}
+
+	if !received(ch) {
+		t.Fatal("expected at least one pending signal")
+	}
+	if received(ch) {
+		t.Fatal("expected signals to coalesce into a single pending slot")
+	}
+}
+
+func TestBrokerNormalizesTrailingSlash(t *testing.T) {
+	b := newBroker()
+	// Subscribe without a trailing slash; Notify without one either.
+	ch, unsub := b.Subscribe("root")
+	defer unsub()
+
+	b.Notify("root")
+	if !received(ch) {
+		t.Fatal("expected trailing-slash normalization to match paths")
+	}
+}

--- a/http/handler.go
+++ b/http/handler.go
@@ -60,6 +60,7 @@ func NewHandler(ctx context.Context, config HandlerConfig) (http.Handler, error)
 func handle(ctx context.Context, hc HandlerConfig) http.Handler {
 	logger := logging.Ctx(ctx)
 	mux := http.NewServeMux()
+	brk := newBroker()
 
 	if uiExists {
 		mux.Handle("/ui/", otelhttp.NewHandler(gziphandler.GzipHandler(http.StripPrefix("/ui/", http.FileServer(webFS()))), "/ui/"))
@@ -67,7 +68,7 @@ func handle(ctx context.Context, hc HandlerConfig) http.Handler {
 		mux.Handle("/ui/", otelhttp.NewHandler(handleUIEmpty(), "/ui/"))
 	}
 
-	mux.Handle("/v1/chambers/", otelhttp.NewHandler(handleChambers(hc.Storage), "/v1/chambers/"))
+	mux.Handle("/v1/chambers/", otelhttp.NewHandler(handleChambers(hc.Storage, brk), "/v1/chambers/"))
 
 	timeoutHandler := wrapWithTimeout(mux, hc.RequestTimeout)
 	return wrapCommonHandler(timeoutHandler, logger)
@@ -75,6 +76,12 @@ func handle(ctx context.Context, hc HandlerConfig) http.Handler {
 
 func wrapWithTimeout(h http.Handler, t time.Duration) http.Handler {
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		// Streaming (watch) requests are long-lived and must not be subject to
+		// the per-request timeout.
+		if isWatchRequest(r) {
+			h.ServeHTTP(w, r)
+			return
+		}
 		ctx := r.Context()
 		var cancelFunc context.CancelFunc
 		ctx, cancelFunc = context.WithTimeout(ctx, t)
@@ -82,6 +89,11 @@ func wrapWithTimeout(h http.Handler, t time.Duration) http.Handler {
 		h.ServeHTTP(w, r)
 		cancelFunc()
 	})
+}
+
+// isWatchRequest reports whether r is a request to stream chamber changes.
+func isWatchRequest(r *http.Request) bool {
+	return r.Method == http.MethodGet && r.URL.Query().Get("watch") == "true"
 }
 func wrapCommonHandler(h http.Handler, logger *logging.TracedLogger) http.Handler {
 	meter := otel.Meter("github.com/steviebps/realm")
@@ -139,7 +151,7 @@ func handleError(ctx context.Context, w http.ResponseWriter, status int, resp ap
 	_ = utils.WriteInterfaceWith(w, resp, true)
 }
 
-func handleChambers(strg storage.Storage) http.Handler {
+func handleChambers(strg storage.Storage, brk *broker) http.Handler {
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		defer r.Body.Close()
 		ctx := r.Context()
@@ -152,6 +164,11 @@ func handleChambers(strg storage.Storage) http.Handler {
 
 		switch req.Operation {
 		case GetOperation:
+			if isWatchRequest(r) {
+				streamChamber(w, r, strg, brk, req.Path)
+				return
+			}
+
 			entry, err := strg.Get(ctx, req.Path)
 			if err != nil {
 				span.SetStatus(codes.Error, err.Error())
@@ -203,6 +220,7 @@ func handleChambers(strg storage.Storage) http.Handler {
 				return
 			}
 
+			brk.Notify(req.Path)
 			handleWithStatus(w, http.StatusCreated, nil)
 			return
 
@@ -268,6 +286,7 @@ func handleChambers(strg storage.Storage) http.Handler {
 				return
 			}
 
+			brk.Notify(req.Path)
 			handleOk(w, nil)
 			return
 
@@ -285,6 +304,8 @@ func handleChambers(strg storage.Storage) http.Handler {
 				handleError(ctx, w, http.StatusInternalServerError, createResponseWithErrors(nil, []string{err.Error()}))
 				return
 			}
+
+			brk.Notify(req.Path)
 			handleOk(w, nil)
 			return
 
@@ -314,6 +335,75 @@ func handleChambers(strg storage.Storage) http.Handler {
 			handleError(ctx, w, http.StatusMethodNotAllowed, createResponseWithErrors(nil, []string{http.StatusText(http.StatusMethodNotAllowed)}))
 		}
 	})
+}
+
+// streamChamber holds an SSE connection open and pushes the chamber at path
+// whenever it changes. It sends the current chamber immediately, then re-sends
+// on every change signal from the broker, and emits periodic heartbeats so dead
+// connections and idle intermediaries are handled.
+func streamChamber(w http.ResponseWriter, r *http.Request, strg storage.Storage, brk *broker, path string) {
+	ctx := r.Context()
+	logger := logging.Ctx(ctx)
+	span := trace.SpanFromContext(ctx)
+	span.SetAttributes(attribute.Bool("realm.server.watch", true))
+
+	flusher, ok := w.(http.Flusher)
+	if !ok {
+		handleError(ctx, w, http.StatusInternalServerError, createResponseWithErrors(nil, []string{"streaming is not supported"}))
+		return
+	}
+
+	w.Header().Set("Content-Type", "text/event-stream")
+	w.Header().Set("Cache-Control", "no-cache")
+	w.Header().Set("Connection", "keep-alive")
+
+	signals, unsubscribe := brk.Subscribe(path)
+	defer unsubscribe()
+
+	// send writes the current chamber as a single SSE event. Stored chamber
+	// values are compact JSON (single line), so they are safe as SSE data.
+	// It returns false when the connection should be torn down.
+	send := func() bool {
+		entry, err := strg.Get(ctx, path)
+		if err != nil {
+			// A not-yet-existing chamber is not fatal for a stream; wait for it
+			// to be created rather than closing the connection.
+			var nfError *storage.NotFoundError
+			if errors.As(err, &nfError) {
+				return true
+			}
+			logger.ErrorCtx(ctx).Str("path", path).Msg(err.Error())
+			return false
+		}
+		if _, err := fmt.Fprintf(w, "event: chamber\ndata: %s\n\n", entry.Value); err != nil {
+			return false
+		}
+		flusher.Flush()
+		return true
+	}
+
+	if !send() {
+		return
+	}
+
+	heartbeat := time.NewTicker(30 * time.Second)
+	defer heartbeat.Stop()
+
+	for {
+		select {
+		case <-ctx.Done():
+			return
+		case <-signals:
+			if !send() {
+				return
+			}
+		case <-heartbeat.C:
+			if _, err := fmt.Fprint(w, ": ping\n\n"); err != nil {
+				return
+			}
+			flusher.Flush()
+		}
+	}
 }
 
 func handleUIEmpty() http.Handler {

--- a/http/stream_test.go
+++ b/http/stream_test.go
@@ -1,0 +1,98 @@
+package http
+
+import (
+	"bufio"
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/steviebps/realm/pkg/storage"
+)
+
+func newTestHandler(t *testing.T) http.Handler {
+	t.Helper()
+	stg, err := storage.NewBigCacheStorage(map[string]string{})
+	if err != nil {
+		t.Fatalf("could not create storage: %v", err)
+	}
+	h, err := NewHandler(context.Background(), HandlerConfig{Storage: stg, RequestTimeout: DefaultHandlerTimeout})
+	if err != nil {
+		t.Fatalf("could not create handler: %v", err)
+	}
+	return h
+}
+
+func putChamber(t *testing.T, baseURL, path, body string) {
+	t.Helper()
+	resp, err := http.Post(baseURL+"/v1/chambers/"+path, "application/json", strings.NewReader(body))
+	if err != nil {
+		t.Fatalf("put %q: %v", path, err)
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusCreated {
+		t.Fatalf("put %q: expected 201, got %d", path, resp.StatusCode)
+	}
+}
+
+// dataEvents reads an SSE body and emits the payload of each `data:` line.
+func dataEvents(scanner *bufio.Scanner) <-chan string {
+	out := make(chan string)
+	go func() {
+		defer close(out)
+		for scanner.Scan() {
+			line := scanner.Text()
+			if strings.HasPrefix(line, "data:") {
+				out <- strings.TrimSpace(strings.TrimPrefix(line, "data:"))
+			}
+		}
+	}()
+	return out
+}
+
+func waitData(t *testing.T, events <-chan string, timeout time.Duration) string {
+	t.Helper()
+	select {
+	case d, ok := <-events:
+		if !ok {
+			t.Fatal("event stream closed unexpectedly")
+		}
+		return d
+	case <-time.After(timeout):
+		t.Fatal("timed out waiting for an SSE event")
+		return ""
+	}
+}
+
+func TestStreamChamberPushesInitialAndUpdates(t *testing.T) {
+	srv := httptest.NewServer(newTestHandler(t))
+	defer srv.Close()
+
+	putChamber(t, srv.URL, "root", `{"rules":{"flag":{"type":"string","value":"one"}}}`)
+
+	req, _ := http.NewRequest(http.MethodGet, srv.URL+"/v1/chambers/root?watch=true", nil)
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		t.Fatalf("open stream: %v", err)
+	}
+	defer resp.Body.Close()
+
+	if ct := resp.Header.Get("Content-Type"); !strings.HasPrefix(ct, "text/event-stream") {
+		t.Fatalf("expected text/event-stream, got %q", ct)
+	}
+
+	events := dataEvents(bufio.NewScanner(resp.Body))
+
+	if first := waitData(t, events, 2*time.Second); !strings.Contains(first, `"one"`) {
+		t.Fatalf("initial event missing seeded value: %s", first)
+	}
+
+	// A subsequent write must be pushed to the open stream.
+	putChamber(t, srv.URL, "root", `{"rules":{"flag":{"type":"string","value":"two"}}}`)
+
+	if second := waitData(t, events, 2*time.Second); !strings.Contains(second, `"two"`) {
+		t.Fatalf("update event missing new value: %s", second)
+	}
+}

--- a/pkg/realm.go
+++ b/pkg/realm.go
@@ -26,6 +26,7 @@ type Realm struct {
 	initSync           sync.Once
 	stopCh             chan struct{}
 	cancel             context.CancelFunc
+	wg                 sync.WaitGroup
 	mu                 sync.RWMutex
 	root               *ChamberEntry
 	client             *client.HttpClient
@@ -167,11 +168,15 @@ func (rlm *Realm) Start() error {
 		return err
 	}
 
-	if rlm.streaming {
-		go rlm.stream(ctx)
-	} else {
-		go rlm.poll(ctx)
-	}
+	rlm.wg.Add(1)
+	go func() {
+		defer rlm.wg.Done()
+		if rlm.streaming {
+			rlm.stream(ctx)
+		} else {
+			rlm.poll(ctx)
+		}
+	}()
 
 	return nil
 }
@@ -290,12 +295,13 @@ func (rlm *Realm) consumeStream(ctx context.Context) (supported bool, received b
 	return true, received, scanner.Err()
 }
 
-// Stop stops realm and flushes any pending tasks
+// Stop stops realm and blocks until the background refresh goroutine has exited.
 func (rlm *Realm) Stop() {
 	close(rlm.stopCh)
 	if rlm.cancel != nil {
 		rlm.cancel()
 	}
+	rlm.wg.Wait()
 }
 
 func (rlm *Realm) retrieveChamber(ctx context.Context, path string) (*Chamber, error) {

--- a/pkg/realm.go
+++ b/pkg/realm.go
@@ -1,10 +1,12 @@
 package realm
 
 import (
+	"bufio"
 	"context"
 	"encoding/json"
 	"errors"
 	"fmt"
+	"net/http"
 	"strings"
 	"sync"
 	"time"
@@ -23,10 +25,12 @@ type Realm struct {
 	path               string
 	initSync           sync.Once
 	stopCh             chan struct{}
+	cancel             context.CancelFunc
 	mu                 sync.RWMutex
 	root               *ChamberEntry
 	client             *client.HttpClient
 	pollingInterval    time.Duration
+	streaming          bool
 	logger             *logging.TracedLogger
 	tracer             trace.Tracer
 }
@@ -37,6 +41,9 @@ type RealmConfig struct {
 	applicationVersion string
 	// pollingInterval is how often realm will refetch the chamber from the realm server
 	pollingInterval time.Duration
+	// streaming makes realm keep its chamber current via a server-sent-events
+	// stream (with polling as an automatic fallback) instead of only polling
+	streaming bool
 }
 
 const (
@@ -98,6 +105,17 @@ func WithVersion(version string) RealmOption {
 	})
 }
 
+// WithStreaming enables real-time updates over a server-sent-events stream. When
+// enabled, realm applies chamber changes as the server pushes them, reconnecting
+// with backoff and falling back to polling if the server does not support
+// streaming. Defaults to false (polling only).
+func WithStreaming(streaming bool) RealmOption {
+	return realmOptionFunc(func(rc RealmConfig) RealmConfig {
+		rc.streaming = streaming
+		return rc
+	})
+}
+
 // NewRealm returns a new Realm struct that carries out all of the core features
 func NewRealm(options ...RealmOption) (*Realm, error) {
 	cfg := RealmConfig{}
@@ -128,13 +146,15 @@ func NewRealm(options ...RealmOption) (*Realm, error) {
 		applicationVersion: cfg.applicationVersion,
 		stopCh:             make(chan struct{}),
 		pollingInterval:    cfg.pollingInterval,
+		streaming:          cfg.streaming,
 	}, nil
 }
 
 // Start starts realm and initializes the underlying chamber
 func (rlm *Realm) Start() error {
 	var err error
-	ctx := rlm.logger.WithContext(context.Background())
+	ctx, cancel := context.WithCancel(rlm.logger.WithContext(context.Background()))
+	rlm.cancel = cancel
 	rlm.initSync.Do(func() {
 		var chamber *Chamber
 		if chamber, err = rlm.retrieveChamber(ctx, rlm.path); err == nil {
@@ -143,31 +163,139 @@ func (rlm *Realm) Start() error {
 	})
 
 	if err != nil {
+		cancel()
 		return err
 	}
 
-	go func() {
-		ticker := time.NewTicker(rlm.pollingInterval)
-		defer ticker.Stop()
-		for {
-			select {
-			case <-rlm.stopCh:
-				rlm.logger.InfoCtx(ctx).Msg("shutting down realm")
-				return
-			case <-ticker.C:
-				if chamber, err := rlm.retrieveChamber(ctx, rlm.path); err == nil {
-					rlm.setChamber(chamber)
-				}
-			}
-		}
-	}()
+	if rlm.streaming {
+		go rlm.stream(ctx)
+	} else {
+		go rlm.poll(ctx)
+	}
 
 	return nil
+}
+
+// poll refreshes the chamber snapshot on a fixed interval until realm is stopped.
+func (rlm *Realm) poll(ctx context.Context) {
+	ticker := time.NewTicker(rlm.pollingInterval)
+	defer ticker.Stop()
+	for {
+		select {
+		case <-rlm.stopCh:
+			rlm.logger.InfoCtx(ctx).Msg("shutting down realm")
+			return
+		case <-ticker.C:
+			if chamber, err := rlm.retrieveChamber(ctx, rlm.path); err == nil {
+				rlm.setChamber(chamber)
+			}
+		}
+	}
+}
+
+// stream keeps the chamber snapshot current from a server-sent-events stream,
+// reconnecting with capped exponential backoff. If the server does not support
+// streaming, it falls back to polling permanently.
+func (rlm *Realm) stream(ctx context.Context) {
+	const (
+		initialBackoff = 1 * time.Second
+		maxBackoff     = 30 * time.Second
+	)
+	backoff := initialBackoff
+
+	for {
+		select {
+		case <-rlm.stopCh:
+			rlm.logger.InfoCtx(ctx).Msg("shutting down realm")
+			return
+		default:
+		}
+
+		supported, received, err := rlm.consumeStream(ctx)
+		if !supported {
+			rlm.logger.InfoCtx(ctx).Msg("realm server does not support streaming; falling back to polling")
+			rlm.poll(ctx)
+			return
+		}
+		if err != nil {
+			rlm.logger.ErrorCtx(ctx).Str("error", err.Error()).Msg("chamber stream disconnected; reconnecting")
+		}
+		if received {
+			backoff = initialBackoff
+		}
+
+		select {
+		case <-rlm.stopCh:
+			return
+		case <-time.After(backoff):
+		}
+
+		if !received {
+			backoff *= 2
+			if backoff > maxBackoff {
+				backoff = maxBackoff
+			}
+		}
+	}
+}
+
+// consumeStream opens one streaming connection and applies chamber updates until
+// it drops. It reports whether the server supports streaming (false means the
+// caller should fall back to polling) and whether at least one event was
+// applied (used to reset reconnect backoff).
+func (rlm *Realm) consumeStream(ctx context.Context) (supported bool, received bool, err error) {
+	ctx, span := rlm.tracer.Start(ctx, "consumeStream", trace.WithAttributes(attribute.String("realm.path", rlm.path)))
+	defer span.End()
+
+	resp, err := rlm.client.Watch(ctx, rlm.path)
+	if err != nil {
+		// A transient connection error: keep retrying the stream.
+		return true, false, err
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK || !strings.HasPrefix(resp.Header.Get("Content-Type"), "text/event-stream") {
+		// The server did not give us an event stream (older server, or the watch
+		// parameter is unsupported): fall back to polling.
+		return false, false, nil
+	}
+
+	scanner := bufio.NewScanner(resp.Body)
+	scanner.Buffer(make([]byte, 0, 64*1024), 1024*1024)
+
+	var data strings.Builder
+	for scanner.Scan() {
+		line := scanner.Text()
+		switch {
+		case strings.HasPrefix(line, "data:"):
+			data.WriteString(strings.TrimSpace(strings.TrimPrefix(line, "data:")))
+		case line == "":
+			// blank line terminates an event
+			if data.Len() == 0 {
+				continue
+			}
+			var c Chamber
+			if uerr := json.Unmarshal([]byte(data.String()), &c); uerr != nil {
+				rlm.logger.ErrorCtx(ctx).Str("error", uerr.Error()).Msg("could not unmarshal streamed chamber")
+			} else {
+				rlm.setChamber(&c)
+				received = true
+			}
+			data.Reset()
+		default:
+			// comment/heartbeat (": ping") or other SSE fields (event:, id:) — ignore
+		}
+	}
+
+	return true, received, scanner.Err()
 }
 
 // Stop stops realm and flushes any pending tasks
 func (rlm *Realm) Stop() {
 	close(rlm.stopCh)
+	if rlm.cancel != nil {
+		rlm.cancel()
+	}
 }
 
 func (rlm *Realm) retrieveChamber(ctx context.Context, path string) (*Chamber, error) {

--- a/pkg/realm_stream_test.go
+++ b/pkg/realm_stream_test.go
@@ -1,0 +1,135 @@
+package realm
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/steviebps/realm/client"
+)
+
+func chamberJSON(v string) string {
+	return fmt.Sprintf(`{"rules":{"msg":{"type":"string","value":%q}}}`, v)
+}
+
+func eventually(d time.Duration, cond func() bool) bool {
+	deadline := time.Now().Add(d)
+	for time.Now().Before(deadline) {
+		if cond() {
+			return true
+		}
+		time.Sleep(10 * time.Millisecond)
+	}
+	return cond()
+}
+
+func newStreamingRealm(t *testing.T, address string, pollingInterval time.Duration) *Realm {
+	t.Helper()
+	c, err := client.NewHttpClient(&client.HttpClientConfig{Address: address})
+	if err != nil {
+		t.Fatalf("client: %v", err)
+	}
+	rlm, err := NewRealm(WithHttpClient(c), WithPath("root"), WithStreaming(true), WithPollingInterval(pollingInterval))
+	if err != nil {
+		t.Fatalf("realm: %v", err)
+	}
+	return rlm
+}
+
+// TestRealmStreamingAppliesPushedUpdates verifies the SDK applies a chamber
+// pushed over SSE without waiting for the polling interval (set to 1h here).
+func TestRealmStreamingAppliesPushedUpdates(t *testing.T) {
+	var mu sync.Mutex
+	value := "one"
+	get := func() string { mu.Lock(); defer mu.Unlock(); return value }
+
+	update := make(chan struct{})
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Query().Get("watch") == "true" {
+			w.Header().Set("Content-Type", "text/event-stream")
+			f, ok := w.(http.Flusher)
+			if !ok {
+				t.Error("expected a flushable ResponseWriter")
+				return
+			}
+			fmt.Fprintf(w, "event: chamber\ndata: %s\n\n", chamberJSON(get()))
+			f.Flush()
+			select {
+			case <-update:
+				fmt.Fprintf(w, "event: chamber\ndata: %s\n\n", chamberJSON(get()))
+				f.Flush()
+			case <-r.Context().Done():
+				return
+			}
+			<-r.Context().Done()
+			return
+		}
+		// normal GET used by Start()'s initial synchronous load
+		fmt.Fprintf(w, `{"data":%s}`, chamberJSON(get()))
+	}))
+	defer srv.Close()
+
+	rlm := newStreamingRealm(t, srv.URL, time.Hour)
+	if err := rlm.Start(); err != nil {
+		t.Fatalf("start: %v", err)
+	}
+	defer rlm.Stop()
+
+	if got, _ := rlm.String(context.Background(), "msg", "default"); got != "one" {
+		t.Fatalf("expected initial value 'one', got %q", got)
+	}
+
+	mu.Lock()
+	value = "two"
+	mu.Unlock()
+	close(update)
+
+	if !eventually(2*time.Second, func() bool {
+		got, _ := rlm.String(context.Background(), "msg", "default")
+		return got == "two"
+	}) {
+		t.Fatal("streamed update was not applied to the local snapshot")
+	}
+}
+
+// TestRealmStreamingFallsBackToPolling verifies that when the server does not
+// return an event stream, the SDK converges via polling instead.
+func TestRealmStreamingFallsBackToPolling(t *testing.T) {
+	var mu sync.Mutex
+	value := "one"
+	get := func() string { mu.Lock(); defer mu.Unlock(); return value }
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		// Ignore the watch parameter entirely (simulating an older server) and
+		// always return a normal JSON response.
+		w.Header().Set("Content-Type", "application/json")
+		fmt.Fprintf(w, `{"data":%s}`, chamberJSON(get()))
+	}))
+	defer srv.Close()
+
+	rlm := newStreamingRealm(t, srv.URL, 50*time.Millisecond)
+	if err := rlm.Start(); err != nil {
+		t.Fatalf("start: %v", err)
+	}
+	defer rlm.Stop()
+
+	if got, _ := rlm.String(context.Background(), "msg", "default"); got != "one" {
+		t.Fatalf("expected initial value 'one', got %q", got)
+	}
+
+	mu.Lock()
+	value = "two"
+	mu.Unlock()
+
+	if !eventually(2*time.Second, func() bool {
+		got, _ := rlm.String(context.Background(), "msg", "default")
+		return got == "two"
+	}) {
+		t.Fatal("expected polling fallback to pick up the update")
+	}
+}


### PR DESCRIPTION
## Summary

Push chamber changes to SDKs the moment they happen, over **server-sent events**, instead of waiting for the polling interval. This closes the "immediately sourced" gap from the roadmap in `docs/ARCHITECTURE.md`.

Builds on the foundation + percentage-rollout work already merged in #84. Fully backward compatible — streaming is **opt-in** and polling is unchanged when it's off.

## Server

- **In-process change broker** (`http/broker.go`): watchers subscribe by path; each write `Notify`s by path **prefix**, so a change to an inherited parent chamber refreshes child watchers. Signals are non-blocking and coalesced (a slow client can never block a writer).
- **SSE endpoint** `GET /v1/chambers/<path>?watch=true` returns `text/event-stream`: emits the current chamber on connect, again on every change, plus periodic heartbeats. It reuses `storage.Get`, so inheritance and validation are identical to a normal read, and bypasses the per-request timeout. `Notify` is wired into `Put`/`Patch`/`Delete`.

## SDK

- `client.Watch` opens a long-lived, no-timeout streaming connection.
- `Realm.WithStreaming(true)` runs a stream loop that applies pushed chambers, reconnects with capped exponential backoff, and **falls back to polling** if the server doesn't return an event stream (detected via `Content-Type`). `Stop()` cancels the stream promptly.

```go
rlm, _ := realm.NewRealm(
	realm.WithHttpClient(c),
	realm.WithPath("root"),
	realm.WithStreaming(true), // real-time updates, with polling fallback
)
```

## Known limitation (documented)

The broker is process-local: with multiple server replicas, a write handled by replica A doesn't push to watchers on replica B; they converge on their next reconnect/poll. Cross-replica fanout is a follow-up, noted in `docs/ARCHITECTURE.md`.

## Verification

- `go test -race ./...` and `golangci-lint` green.
- Tests: broker prefix/coalesce/unsubscribe; SSE handler end-to-end via `httptest`; SDK streaming-apply and polling-fallback.
- Manual, against a live `--dev` server: a `curl -N '…?watch=true'` stream received the initial chamber, then the updated chamber the instant a change was `POST`ed.

## Docs

`docs/ARCHITECTURE.md` (streaming marked done + endpoint/limitation), `README.md`, and `CLAUDE.md` updated for `WithStreaming`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_017HNerxoZ4cT4tEiZNrPiiA)_